### PR TITLE
update go module path

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -2,7 +2,7 @@ domain: pipeline-service.io
 layout:
 - go.kubebuilder.io/v3
 projectName: settings-controller
-repo: github.com/fgiloux/settings-controller
+repo: github.com/openshift-pipelines/pipeline-service-workspace-controller
 resources:
 - api:
     crdVersion: v1
@@ -11,7 +11,7 @@ resources:
   domain: pipeline-service.io
   group: configuration
   kind: Settings
-  path: github.com/fgiloux/settings-controller/api/v1alpha1
+  path: github.com/openshift-pipelines/pipeline-service-workspace-controller/api/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1
@@ -19,6 +19,6 @@ resources:
   domain: pipeline-service.io
   group: configuration
   kind: SettingsConfig
-  path: github.com/fgiloux/settings-controller/api/v1alpha1
+  path: github.com/openshift-pipelines/pipeline-service-workspace-controller/api/v1alpha1
   version: v1alpha1
 version: "3"

--- a/controllers/settings_controller.go
+++ b/controllers/settings_controller.go
@@ -16,8 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	cutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	settingsv1alpha1 "github.com/fgiloux/settings-controller/api/v1alpha1"
 	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+	settingsv1alpha1 "github.com/openshift-pipelines/pipeline-service-workspace-controller/api/v1alpha1"
 )
 
 type SettingsReconciler struct {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -14,7 +14,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	settingsv1alpha1 "github.com/fgiloux/settings-controller/api/v1alpha1"
+	settingsv1alpha1 "github.com/openshift-pipelines/pipeline-service-workspace-controller/api/v1alpha1"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/fgiloux/settings-controller
+module github.com/openshift-pipelines/pipeline-service-workspace-controller
 
 go 1.18
 

--- a/main.go
+++ b/main.go
@@ -22,10 +22,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/kcp"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	settingsv1alpha1 "github.com/fgiloux/settings-controller/api/v1alpha1"
+	settingsv1alpha1 "github.com/openshift-pipelines/pipeline-service-workspace-controller/api/v1alpha1"
 	// +kubebuilder:scaffold:imports
 
-	"github.com/fgiloux/settings-controller/controllers"
+	"github.com/openshift-pipelines/pipeline-service-workspace-controller/controllers"
 
 	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
 )


### PR DESCRIPTION
This PR aims at updating go module path to reflect github.com/openshift-pipelines/pipeline-service-workspace-controller.

Signed-off-by: Satyam Bhardwaj <sabhardw@redhat.com>