### PR TITLE
Initial set of fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The parameter specifying the workspace where the APIExport is located needs to b
 Deploy the operator to kcp with the image specified by `IMG`:
 
 ```sh
-make deploy IMG=<some-registry>/settings-operator:tag
+KUBECONFIG=path/to/kcp.kubeconfig make deploy IMG=<some-registry>/settings-operator:tag
 ```
 
 ### Uninstalling resources
@@ -37,7 +37,7 @@ make deploy IMG=<some-registry>/settings-operator:tag
 To delete the resources from kcp:
 
 ```sh
-make uninstall
+KUBECONFIG=path/to/kcp.kubeconfig make uninstall
 ```
 
 ### Undeploying the operator
@@ -45,7 +45,7 @@ make uninstall
 Undeploy the operator from kcp:
 
 ```sh
-make undeploy
+KUBECONFIG=path/to/kcp.kubeconfig make undeploy
 ```
 
 ## Contributing
@@ -54,7 +54,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ### How it works
 
-This project aims to follow the Kubernetes [Operator pattern](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/)
+This project aims to follow the Kubernetes [Operator pattern](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/).
 
 It uses [Controllers](https://kubernetes.io/docs/concepts/architecture/controller/) 
 which provides a reconcile function responsible for synchronizing resources until the desired state is reached. 
@@ -64,13 +64,13 @@ which provides a reconcile function responsible for synchronizing resources unti
 1. Install the required resources into kcp:
 
 ```sh
-make install
+KUBECONFIG=path/to/kcp.kubeconfig make install
 ```
 
 2. Run the operator (this will run in the foreground, so switch to a new terminal if you want to leave it running):
 
 ```sh
-make run ARGS="-v=6 --zap-log-level=6 --zap-devel=true --config=config/manager/controller_manager_config_test.yaml --api-export-name=settings-configuration.pipeline-service.io --api-export-workspace=<installation-ws>"
+KUBECONFIG=path/to/kcp.kubeconfig make run ARGS="-v=6 --zap-log-level=6 --zap-devel=true --config=config/manager/controller_manager_config_test.yaml --api-export-name=settings-configuration.pipeline-service.io --api-export-workspace=<installation-ws>"
 ```
 
 **NOTE:** You can also run this in one step by running: `make install run`
@@ -90,7 +90,7 @@ Here is an example of a launch configuration for VSCode
             "program": "${workspaceFolder}/main.go",
             "args": [
                 "--api-export-name", "settings-configuration.pipeline-service.io"
-                "--api-export-workspace","root:pipeline-service:management"
+                "--api-export-workspace","root:default:pipeline-service-compute"
                 "--config", "config/manager/controller_manager_config_test.yaml"
                 "--zap-log-level", "6"
                 "--zap-devel", "true"

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -8,11 +8,7 @@ namespace: settings-ps-controller
 # field above.
 namePrefix: settings-
 
-# Labels to add to all resources and selectors.
-#commonLabels:
-#  someName: someValue
-
-bases:
+resources:
 - ../kcp
 - ../rbac
 - ../manager
@@ -78,4 +74,4 @@ vars:
     kind: APIExport
     name: configuration.pipeline-service.io
   fieldref:
-    fieldPath: metadata.name
+    fieldpath: metadata.name

--- a/config/default/manager_config_patch.yaml
+++ b/config/default/manager_config_patch.yaml
@@ -11,7 +11,7 @@ spec:
         args:
         - "--config=controller_manager_config.yaml"
         - "--api-export-name=$(API_EXPORT_NAME)"
-        - "--api-export-workspace=root:pipeline-service:management"
+        - "--api-export-workspace=root:default:pipeline-service-compute"
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"
         - "--leader-elect"

--- a/config/kcp/apibinding.yaml
+++ b/config/kcp/apibinding.yaml
@@ -1,13 +1,13 @@
 apiVersion: apis.kcp.dev/v1alpha1
 kind: APIBinding
 metadata:
-  name: settings-configuration.pipeline-service.io
+  name: configuration.pipeline-service.io
 spec:
   reference:
     workspace:
       exportName: settings-configuration.pipeline-service.io
       # TODO: the path needs to match the location of the apiexport
-      path: root:pipeline-service:management
+      path: root:default:pipeline-service-compute
   permissionClaims:
   - group: "apis.kcp.dev"
     resource: "apibindings"
@@ -17,7 +17,7 @@ spec:
     state: Accepted
     # identityHash needs to match the export of the workload cluster
     # it can be set with: make patch-identity
-    identityHash: "a1171f89c2274572ac14ee99f6f733069ae14ce41db83ba550da58e8f4802b72"
+    identityHash: "36d45824f68eba565152ccf6a07f17a45d0d6d34d0c5642046eee6f55ec2f961"
   - group: ""
     resource: "resourcequotas"
     state: Accepted

--- a/config/kcp/apiexport.yaml
+++ b/config/kcp/apiexport.yaml
@@ -12,7 +12,7 @@ spec:
     resource: networkpolicies
     # identityHash needs to match the export of the workload cluster
     # it can be set with: make patch-identity 
-    identityHash: "a1171f89c2274572ac14ee99f6f733069ae14ce41db83ba550da58e8f4802b72"
+    identityHash: "36d45824f68eba565152ccf6a07f17a45d0d6d34d0c5642046eee6f55ec2f961"
   - group: ""
     resource: "resourcequotas"
   - group: ""

--- a/config/kcp/kustomization.yaml
+++ b/config/kcp/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 resources:
   - today.apiresourceschemas.yaml
   - apiexport.yaml

--- a/config/manager/controller_manager_config.yaml
+++ b/config/manager/controller_manager_config.yaml
@@ -9,7 +9,7 @@ webhook:
 leaderElection:
   leaderElect: true
   resourceName: 67a0541b.pipeline-service.io
-namespace: settings-ps-controller
+namespace: admin
 networkPolicyConfig:
   spec:
     podSelector:
@@ -21,8 +21,7 @@ networkPolicyConfig:
 quotaConfig:
   spec:
     hard:
-      count/deployments.apps: "0"
+      count/deployments.apps: "1"
       count/pipelineruns.tekton.dev: "10"
       count/pipelines.tekton.dev: 1k
       count/runs.tekton.dev: "10"
-

--- a/config/manager/controller_manager_config_test.yaml
+++ b/config/manager/controller_manager_config_test.yaml
@@ -8,7 +8,7 @@ webhook:
   port: 9443
 leaderElection:
   leaderElect: false
-namespace: settings-ps-controller
+namespace: admin
 networkPolicyConfig:
   spec:
     podSelector:
@@ -20,8 +20,7 @@ networkPolicyConfig:
 quotaConfig:
   spec:
     hard:
-      count/deployments.apps: "0"
+      count/deployments.apps: "1"
       count/pipelineruns.tekton.dev: "10"
       count/pipelines.tekton.dev: 1k
       count/runs.tekton.dev: "10"
-

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 resources:
 - manager.yaml
 
@@ -12,5 +13,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/fgiloux/settings-operator
+  newName: quay.io/redhat-pipeline-service/settings-operator
   newTag: latest

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -31,7 +31,7 @@ spec:
         - /manager
         args:
         - --api-export-name=settings-configuration.pipeline-service.io
-        - --api-export-workspace="root:pipeline-service:management"
+        - --api-export-workspace="root:default:pipeline-service-compute"
         - --leader-elect
         - -v 2
         image: controller:latest
@@ -56,7 +56,7 @@ spec:
           periodSeconds: 10
         resources:
           limits:
-            cpu: 1
+            cpu: "1"
             memory: 128Mi
           requests:
             cpu: 10m

--- a/go.mod
+++ b/go.mod
@@ -5,14 +5,14 @@ go 1.18
 require (
 	// github.com/kcp-dev/kcp/pkg/apis v0.5.0-alpha.1
 	github.com/kcp-dev/kcp/pkg/apis v0.7.0
-	github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.1
+	github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.3
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.18.1
 	k8s.io/api v0.24.3
 	k8s.io/apimachinery v0.24.3
 	k8s.io/client-go v0.24.3
 	k8s.io/klog/v2 v2.60.1
-	sigs.k8s.io/controller-runtime v0.11.2
+	sigs.k8s.io/controller-runtime v0.12.2
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -320,6 +320,8 @@ github.com/kcp-dev/kcp/pkg/apis v0.7.0 h1:WFce+8OSM+86/1w52VhNsQ6wkvvTdl41gqSpsb
 github.com/kcp-dev/kcp/pkg/apis v0.7.0/go.mod h1:jwvDdhVuswpwqCriyr7frT3Ak23OzuFoVRjqSvfFiRk=
 github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.1 h1:6EMfOioekQNrpcHEK7k2ANBWogFMlf+3xTB3CC4k+2s=
 github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.1/go.mod h1:lfWJL764jKFJxZWOGuFuT3PCCLPo6lV5Cl8P7u9T05g=
+github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.3 h1:+DwIG/loh2nDB9c/FqNvLzFFq/YtBliLxAfw/uWNzyE=
+github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.3/go.mod h1:lfWJL764jKFJxZWOGuFuT3PCCLPo6lV5Cl8P7u9T05g=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=


### PR DESCRIPTION
Changes in the PR include:
- Created a new repo called 'settings-operator' in redhat-pipeline-service org in quay.io and updated the references in the codebase.
- Improved README
- Defaulted the value of api-export-workspace to root:default:pipeline-service-compute to align with ckcp.
- Defaulted the value of IMG to quay.io/redhat-pipeline-service/settings-operator so that users won't have to specify the image each time.
- Worked on having the same prefix behaviour in both 'make deploy' mode and 'make install run' mode
- Updated the namespace where resource quota is getting deployed to 'admin'
    - Next PR will have a change to separate the namespace where networkpolicy is deployed.