### PR TITLE
Deploy network policies in pipeline-service namespace and resource quotas in admin namespace instead of one single namespace

### DIFF
--- a/api/v1alpha1/settingsconfig_types.go
+++ b/api/v1alpha1/settingsconfig_types.go
@@ -12,13 +12,15 @@ import (
 type SettingsNetPolConfig struct {
 	// Specification of the desired behavior for this NetworkPolicy.
 	// +optional
-	Spec netv1.NetworkPolicySpec `json:"spec,omitempty"`
+	Namespace string                  `json:"namespace,omitempty"`
+	Spec      netv1.NetworkPolicySpec `json:"spec,omitempty"`
 }
 
 type SettingsQuotaConfig struct {
 	// Defines the desired quota.
 	// +optional
-	Spec corev1.ResourceQuotaSpec `json:"spec,omitempty"`
+	Namespace string                   `json:"namespace,omitempty"`
+	Spec      corev1.ResourceQuotaSpec `json:"spec,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/config/default-crd/kustomization.yaml
+++ b/config/default-crd/kustomization.yaml
@@ -1,5 +1,5 @@
 # Adds namespace to all resources.
-namespace: settings-ps-controller
+namespace: settings-pipeline-service-controller
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
@@ -12,7 +12,7 @@ namePrefix: settings-
 #commonLabels:
 #  someName: someValue
 
-bases:
+resources:
 - ../crd
 - ../rbac
 - ../manager

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,17 +1,8 @@
-# Adds namespace to all resources.
-namespace: settings-ps-controller
-
-# Value of this field is prepended to the
-# names of all resources, e.g. a deployment named
-# "wordpress" becomes "alices-wordpress".
-# Note that it should also match with the prefix (text before '-') of the namespace
-# field above.
-namePrefix: settings-
-
 resources:
 - ../kcp
 - ../rbac
 - ../manager
+
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- ../webhook

--- a/config/kcp/apibinding.yaml
+++ b/config/kcp/apibinding.yaml
@@ -17,7 +17,7 @@ spec:
     state: Accepted
     # identityHash needs to match the export of the workload cluster
     # it can be set with: make patch-identity
-    identityHash: "36d45824f68eba565152ccf6a07f17a45d0d6d34d0c5642046eee6f55ec2f961"
+    identityHash: "17231f31d4e88d067924faaf29738b65255654682c80a3f77f3a71849165f889"
   - group: ""
     resource: "resourcequotas"
     state: Accepted

--- a/config/kcp/apiexport.yaml
+++ b/config/kcp/apiexport.yaml
@@ -12,7 +12,7 @@ spec:
     resource: networkpolicies
     # identityHash needs to match the export of the workload cluster
     # it can be set with: make patch-identity 
-    identityHash: "36d45824f68eba565152ccf6a07f17a45d0d6d34d0c5642046eee6f55ec2f961"
+    identityHash: "17231f31d4e88d067924faaf29738b65255654682c80a3f77f3a71849165f889"
   - group: ""
     resource: "resourcequotas"
   - group: ""

--- a/config/kcp/kustomization.yaml
+++ b/config/kcp/kustomization.yaml
@@ -1,10 +1,21 @@
----
+# Adds namespace to all resources.
+namespace: settings-pipeline-service-controller
+
+# Value of this field is prepended to the
+# names of all resources, e.g. a deployment named
+# "wordpress" becomes "alices-wordpress".
+# Note that it should also match with the prefix (text before '-') of the namespace
+# field above.
+namePrefix: settings-
+
 resources:
-  - today.apiresourceschemas.yaml
-  - apiexport.yaml
-  - apibinding.yaml
-  - clusterrole.yaml
-  - clusterrolebinding.yaml
+- today.apiresourceschemas.yaml
+- apiexport.yaml
+- apibinding.yaml
+- clusterrole.yaml
+- clusterrolebinding.yaml
 
 configurations:
-  - kustomizeconfig.yaml
+- kustomizeconfig.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/config/manager/controller_manager_config.yaml
+++ b/config/manager/controller_manager_config.yaml
@@ -9,8 +9,9 @@ webhook:
 leaderElection:
   leaderElect: true
   resourceName: 67a0541b.pipeline-service.io
-namespace: admin
+namespace: settings-pipeline-service-controller
 networkPolicyConfig:
+  namespace: pipeline-service
   spec:
     podSelector:
       matchLabels:
@@ -19,6 +20,7 @@ networkPolicyConfig:
     - Ingress
     - Egress
 quotaConfig:
+  namespace: admin
   spec:
     hard:
       count/deployments.apps: "1"

--- a/config/manager/controller_manager_config_test.yaml
+++ b/config/manager/controller_manager_config_test.yaml
@@ -8,8 +8,9 @@ webhook:
   port: 9443
 leaderElection:
   leaderElect: false
-namespace: admin
+namespace: settings-pipeline-service-controller
 networkPolicyConfig:
+  namespace: pipeline-service
   spec:
     podSelector:
       matchLabels:
@@ -18,6 +19,7 @@ networkPolicyConfig:
     - Ingress
     - Egress
 quotaConfig:
+  namespace: admin
   spec:
     hard:
       count/deployments.apps: "1"

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,4 +1,13 @@
----
+# Adds namespace to all resources.
+namespace: settings-pipeline-service-controller
+
+# Value of this field is prepended to the
+# names of all resources, e.g. a deployment named
+# "wordpress" becomes "alices-wordpress".
+# Note that it should also match with the prefix (text before '-') of the namespace
+# field above.
+namePrefix: settings-
+
 resources:
 - manager.yaml
 

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -34,7 +34,7 @@ spec:
         - --api-export-workspace="root:default:pipeline-service-compute"
         - --leader-elect
         - -v 2
-        image: controller:latest
+        image: quay.io/redhat-pipeline-service/settings-operator:latest
         name: manager
         volumeMounts:
         - name: config

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,3 +1,13 @@
+# Adds namespace to all resources.
+namespace: settings-pipeline-service-controller
+
+# Value of this field is prepended to the
+# names of all resources, e.g. a deployment named
+# "wordpress" becomes "alices-wordpress".
+# Note that it should also match with the prefix (text before '-') of the namespace
+# field above.
+namePrefix: settings-
+
 resources:
 # All RBAC will be applied under this service account in
 # the deployment namespace. You may comment out this resource

--- a/config/samples/configuration_v1alpha1_settingsconfig.yaml
+++ b/config/samples/configuration_v1alpha1_settingsconfig.yaml
@@ -9,8 +9,9 @@ webhook:
 leaderElection:
   leaderElect: true
   resourceName: 67a0541b.pipeline-service.io
-namespace: settings-ps-controller
+namespace: settings-pipeline-service-controller
 networkPolicyConfig:
+  namespace: pipeline-service
   spec:
     podSelector:
       matchLabels:
@@ -19,6 +20,7 @@ networkPolicyConfig:
     - Ingress
     - Egress
 quotaConfig:
+  namespace: admin
   spec:
     hard:
       count/deployments.apps: "0"


### PR DESCRIPTION
Context:
With the current setup, in default/kustomization.yaml, we have namespace and namePrefix fields that adds namespace to every resource not only under default but also to all the components mentioned in the resources field.

Problem:
This setup is causing issues when we try to create a new namespace in one of the child components. 
Pipeline Service would enforce network isolation via network policies in one namespace named 'pipeline-service'.
Pipeline Service would enforce quotas via resourcequotas that has to be defined in 'admin' namespace as per kcp.
Trying to accomplish this with the current setup causes this issue:

```
[bnr@bnr pipeline-service-workspace-controller]$ kustomize build config/default > temp.yaml
Error: namespace transformation produces ID conflict: [{"apiVersion":"v1","kind":"Namespace","metadata":{"annotations":{"internal.config.kubernetes.io/previousKinds":"Namespace","internal.config.kubernetes.io/previousNames":"pipeline-service","internal.config.kubernetes.io/previousNamespaces":"_non_namespaceable_"},"name":"settings-ps-controller"}} {"apiVersion":"v1","kind":"Namespace","metadata":{"annotations":{"internal.config.kubernetes.io/previousKinds":"Namespace","internal.config.kubernetes.io/previousNames":"admin","internal.config.kubernetes.io/previousNamespaces":"_non_namespaceable_"},"name":"settings-ps-controller"}}]
```

More information about this issue [here](https://github.com/kubernetes-sigs/kustomize/issues/3142).

Solution:
This PR fixes this by moving the namespace and prefix application to the child components and thus having a control at each child/component level. Also made the necessary changes to make sure the resourcequotas and networkpolicies are applied to the respective namespaces.